### PR TITLE
Solr 11722 dsmiley

### DIFF
--- a/solr/core/src/java/org/apache/solr/cloud/CreateCollectionCmd.java
+++ b/solr/core/src/java/org/apache/solr/cloud/CreateCollectionCmd.java
@@ -405,9 +405,6 @@ public class CreateCollectionCmd implements Cmd {
         try {
           Map<String,Object> collectionProps = new HashMap<>();
 
-          // TODO: if collection.configName isn't set, and there isn't already a conf in zk, just use that?
-          String defaultConfigName = System.getProperty(ZkController.COLLECTION_PARAM_PREFIX + ZkController.CONFIGNAME_PROP, collection);
-
           if (params.size() > 0) {
             collectionProps.putAll(params);
             // if the config name wasn't passed in, use the default
@@ -417,6 +414,8 @@ public class CreateCollectionCmd implements Cmd {
             }
 
           } else if (System.getProperty("bootstrap_confdir") != null) {
+            String defaultConfigName = System.getProperty(ZkController.COLLECTION_PARAM_PREFIX + ZkController.CONFIGNAME_PROP, collection);
+
             // if we are bootstrapping a collection, default the config for
             // a new collection to the collection we are bootstrapping
             log.info("Setting config for collection:" + collection + " to " + defaultConfigName);
@@ -445,6 +444,7 @@ public class CreateCollectionCmd implements Cmd {
           stateManager.makePath(collectionPath, Utils.toJSON(zkProps), CreateMode.PERSISTENT, false);
 
         } catch (KeeperException e) {
+          //TODO shouldn't the stateManager ensure this does not happen; should throw AlreadyExistsException
           // it's okay if the node already exists
           if (e.code() != KeeperException.Code.NODEEXISTS) {
             throw e;

--- a/solr/core/src/java/org/apache/solr/cloud/RoutedAliasCreateCollectionCmd.java
+++ b/solr/core/src/java/org/apache/solr/cloud/RoutedAliasCreateCollectionCmd.java
@@ -41,6 +41,7 @@ import org.apache.solr.util.TimeZoneUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.solr.cloud.CreateAliasCmd.CREATE_COLLECTION_PREFIX;
 import static org.apache.solr.cloud.OverseerCollectionMessageHandler.COLL_CONF;
 import static org.apache.solr.common.params.CommonParams.NAME;
 import static org.apache.solr.update.processor.TimeRoutedAliasUpdateProcessor.ROUTER_FIELD_METADATA;
@@ -59,8 +60,6 @@ public class RoutedAliasCreateCollectionCmd implements OverseerCollectionMessage
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   public static final String IF_MOST_RECENT_COLL_NAME = "ifMostRecentCollName";
-
-  public static final String COLL_METAPREFIX = "collection-create.";
 
   private final OverseerCollectionMessageHandler ocmh;
 
@@ -151,16 +150,16 @@ public class RoutedAliasCreateCollectionCmd implements OverseerCollectionMessage
 
   }
 
-   static void createCollectionAndWait(ClusterState clusterState, NamedList results, String aliasName, Map<String, String> aliasMetadata, String createCollName, OverseerCollectionMessageHandler ocmh) throws Exception {
+  static void createCollectionAndWait(ClusterState clusterState, NamedList results, String aliasName, Map<String, String> aliasMetadata, String createCollName, OverseerCollectionMessageHandler ocmh) throws Exception {
     // Map alias metadata starting with a prefix to a create-collection API request
     final ModifiableSolrParams createReqParams = new ModifiableSolrParams();
     for (Map.Entry<String, String> e : aliasMetadata.entrySet()) {
-      if (e.getKey().startsWith(COLL_METAPREFIX)) {
-        createReqParams.set(e.getKey().substring(COLL_METAPREFIX.length()), e.getValue());
+      if (e.getKey().startsWith(CREATE_COLLECTION_PREFIX)) {
+        createReqParams.set(e.getKey().substring(CREATE_COLLECTION_PREFIX.length()), e.getValue());
       }
     }
     if (createReqParams.get(COLL_CONF) == null) {
-      throw new SolrException(SolrException.ErrorCode.SERVER_ERROR,
+      throw new SolrException(SolrException.ErrorCode.BAD_REQUEST,
           "We require an explicit " + COLL_CONF );
     }
     createReqParams.set(NAME, createCollName);

--- a/solr/core/src/java/org/apache/solr/handler/admin/BaseHandlerApiSupport.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/BaseHandlerApiSupport.java
@@ -119,7 +119,7 @@ public abstract class BaseHandlerApiSupport implements ApiSupport {
         } catch (SolrException e) {
           throw e;
         } catch (Exception e) {
-          throw new SolrException(BAD_REQUEST, e);
+          throw new SolrException(BAD_REQUEST, e); //TODO BAD_REQUEST is a wild guess; should we flip the default?  fail here to investigate how this happens in tests
         } finally {
           req.setParams(params);
         }
@@ -199,7 +199,7 @@ public abstract class BaseHandlerApiSupport implements ApiSupport {
 
     @Override
     public Iterator<String> getParameterNamesIterator() {
-      return meta.getParamNames(co).iterator();
+      return meta.getParamNamesIterator(co);
     }
   }
 }

--- a/solr/core/src/java/org/apache/solr/request/SolrRequestInfo.java
+++ b/solr/core/src/java/org/apache/solr/request/SolrRequestInfo.java
@@ -100,7 +100,7 @@ public class SolrRequestInfo {
     return now;
   }
 
-  /** The TimeZone specified by the request, or null if none was specified */
+  /** The TimeZone specified by the request, or UTC if none was specified */
   public TimeZone getClientTimeZone() {
     if (tz == null)  {
       tz = TimeZoneUtils.parseTimezone(req.getParams().get(CommonParams.TZ));

--- a/solr/core/src/java/org/apache/solr/util/DateMathParser.java
+++ b/solr/core/src/java/org/apache/solr/util/DateMathParser.java
@@ -217,12 +217,25 @@ public class DateMathParser  {
   /**
    * Parses a String which may be a date (in the standard ISO-8601 format)
    * followed by an optional math expression.
-   * @param now an optional fixed date to use as "NOW"
+   * The TimeZone is taken from the {@code TZ} param retrieved via {@link SolrRequestInfo}, defaulting to UTC.
+   * @param now an optional fixed date to use as "NOW". {@link SolrRequestInfo} is consulted if unspecified.
    * @param val the string to parse
    */
+  //TODO this API is a bit clumsy.  "now" is rarely used.
   public static Date parseMath(Date now, String val) {
+    return parseMath(now, val, null);
+  }
+
+  /**
+   * Parses a String which may be a date (in the standard ISO-8601 format)
+   * followed by an optional math expression.
+   * @param now an optional fixed date to use as "NOW"
+   * @param val the string to parse
+   * @param zone the timezone to use
+   */
+  public static Date parseMath(Date now, String val, TimeZone zone) {
     String math;
-    final DateMathParser p = new DateMathParser();
+    final DateMathParser p = new DateMathParser(zone);
 
     if (null != now) p.setNow(now);
 

--- a/solr/core/src/java/org/apache/solr/util/TimeZoneUtils.java
+++ b/solr/core/src/java/org/apache/solr/util/TimeZoneUtils.java
@@ -86,7 +86,7 @@ public final class TimeZoneUtils {
 
   /**
    * Parse the specified timezone ID. If null input then return UTC. If we can't resolve it then
-   * throw an exception.
+   * throw an exception.  Does not return null.
    */
   public static TimeZone parseTimezone(String tzStr) {
     if (tzStr != null) {

--- a/solr/core/src/test-files/log4j.properties
+++ b/solr/core/src/test-files/log4j.properties
@@ -29,6 +29,8 @@ log4j.logger.org.apache.solr.hadoop=INFO
 #log4j.logger.org.apache.solr.common.cloud.ClusterStateUtil=DEBUG
 #log4j.logger.org.apache.solr.cloud.OverseerAutoReplicaFailoverThread=DEBUG
 
+#log4j.logger.org.apache.http.wire=DEBUG
+#log4j.logger.org.apache.http.headers=DEBUG
 #log4j.logger.org.apache.http.impl.conn.PoolingHttpClientConnectionManager=DEBUG
 #log4j.logger.org.apache.http.impl.conn.BasicClientConnectionManager=DEBUG
 #log4j.logger.org.apache.http=DEBUG

--- a/solr/core/src/test/org/apache/solr/update/processor/TimeRoutedAliasUpdateProcessorTest.java
+++ b/solr/core/src/test/org/apache/solr/update/processor/TimeRoutedAliasUpdateProcessorTest.java
@@ -78,23 +78,6 @@ public class TimeRoutedAliasUpdateProcessorTest extends SolrCloudTestCase {
     IOUtils.close(solrClient);
   }
 
-  //TODO this is necessary when -Dtests.iters but why? Some other tests aren't affected
-  @Before
-  public void doBefore() throws Exception {
-    // delete aliases first to avoid problems such as: https://issues.apache.org/jira/browse/SOLR-11839
-    ZkStateReader zkStateReader = cluster.getSolrClient().getZkStateReader();
-    zkStateReader.aliasesHolder.applyModificationAndExportToZk(aliases -> {
-      Aliases a = zkStateReader.getAliases();
-      for (String alias : a.getCollectionAliasMap().keySet()) {
-        a = a.cloneWithCollectionAlias(alias,null); // remove
-      }
-      return a;
-    });
-    for (String col : CollectionAdminRequest.listCollections(solrClient)) {
-      CollectionAdminRequest.deleteCollection(col).process(solrClient);
-    }
-  }
-
   @Test
   public void test() throws Exception {
     // First create a config using REST API.  To do this, we create a collection with the name of the eventual config.

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpClusterStateProvider.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpClusterStateProvider.java
@@ -139,6 +139,7 @@ public class HttpClusterStateProvider implements ClusterStateProvider {
     Set<String> liveNodes = new HashSet((List<String>)(cluster.get("live_nodes")));
     this.liveNodes = liveNodes;
     liveNodesTimestamp = System.nanoTime();
+    //TODO SOLR-11877 we don't know the znode path; CLUSTER_STATE is probably wrong leading to bad stateFormat
     ClusterState cs = ClusterState.load(znodeVersion, collectionsMap, liveNodes, ZkStateReader.CLUSTER_STATE);
     if (clusterProperties != null) {
       Map<String, Object> properties = (Map<String, Object>) cluster.get("properties");

--- a/solr/solrj/src/java/org/apache/solr/common/cloud/ZkStateReader.java
+++ b/solr/solrj/src/java/org/apache/solr/common/cloud/ZkStateReader.java
@@ -1460,7 +1460,7 @@ public class ZkStateReader implements Closeable {
       final long deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(30);
       // up-tweaked to better handle ConcurrentCreateRoutedAliasTest.testConcurrentCreateRoutedAliasMinimal()
       // This may be too aggressive but the impact on that test should be validated before changing this.
-      int triesLeft = 50;
+      int triesLeft = 50;//nocommit
       while (triesLeft > 0) {
         triesLeft--;
         // we could synchronize on "this" but there doesn't seem to be a point; we have a retry loop.

--- a/solr/solrj/src/java/org/apache/solr/common/util/JsonSchemaValidator.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/JsonSchemaValidator.java
@@ -236,7 +236,8 @@ class RequiredValidator extends Validator<List<String>> {
       for (String requiredProp : requiredProps) {
         if (requiredProp.contains(".")) {
           if (requiredProp.endsWith(".")) {
-            errs.add("Illegal required attribute name (ends with '.'" + requiredProp + ") This is a bug.");
+            errs.add("Illegal required attribute name (ends with '.': " + requiredProp + ").  This is a bug.");
+            return false;
           }
           String subprop = requiredProp.substring(requiredProp.indexOf(".") + 1);
           if (!validate(((Map)o).get(requiredProp), errs, Collections.singleton(subprop))) {


### PR DESCRIPTION
Wow I took awhile with this.  Here are some of the things I did:

Clean up the test a bit -- many lines changed for many reasons but there is no single big change.  I wanted to minimize each test a bit more to their essential elements, to thus draw attention to what is being tested vs what is incidental.

Plan to do: I think "start" ought to be "router.start".  If there ever ends up being some other routing scheme that isn't time based (hash of some field?) there wouldn't necessarily be a 'start'.  I didn't move it yet but just wanted your input.  My previous statement about "start" not being metadata is still true; these aren't mutually exclusive.

I did some debugging in the V2 to V1 mapping, prompted by my surprise that you found it necessary to invoke it explicitly.  I found a bug in org.apache.solr.client.solrj.request.CollectionApiMapping.Meta, particularly getParamNames which failed to consider "attrToParams" (a mapping).  Thus, our parameters weren't being mapped unless we tried to explicitly ask for each parameter one at a time (which we don't; we iterate to find those starting with "create-collection").  I fixed this and switched this code to use Streams which I found more elegant.  It was necessary to store a reverse mapping too.

Changed the CollectionsHandler createroutedalias_op to only verify that CREATE_OP.execute (for the collection) doesn't throw an exception. That's all we want to do at this stage; the input params can be passed through on to the Overseer Cmd.  This simplified some things.

Removed the redundant collection creation constants in both places.  On the SolrJ side, this was achieved by having CollectionAdminRequest.CreateRoutedAlias accept a "Create" (collection) object with some auto-prefixing.  On the Cmd side there wasn't much to it.

I got very hung up debugging trying to assert the stateFormat, which lead to me filing SOLR-11877.  I commented this assertion out for now.

I also explored a bit some more elegant ways to filter SolrParams but decided against anything interesting in this issue.

I still have to review a little bit more in the CreateAliasCmd towards the bottom.  I also think the value of "50" for retries to modify the alias is high but I didn't debug why you found the need to do so.

Future TODO in other issues:
* BaseHandlerApiSupport:
 throw new SolrException(BAD_REQUEST, e); //TODO BAD_REQUEST is a wild guess; should we flip the default?
* Remove ClusterStateProvider.connect; should auto-connect as needed
* stateFormat bugginess SOLR-11877
* if SolrParams implemented Iterable<Map.Entry<String,String[]>> it would simplify iteration

Right after this gets committed, I want to commit a refactor that coalesces the code around routed aliases a bit more.  I'll create a "RoutedAlias" class which is a POJO for the info about a particular routed alias, and then also have any shared code here needed between some of the components, such as formatting and parsing the collection name for one.